### PR TITLE
Implement deletion method of AVL tree. Fix return values of AVL tree methods.

### DIFF
--- a/lib/src/main/kotlin/tsl/trees/AVLTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/AVLTree.kt
@@ -82,8 +82,10 @@ class AVLTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, AVLNode<K, V>>() 
     private fun getHeight(node: AVLNode<K, V>?) = node?.height ?: -1
 
     override fun delete(key: K): V? {
+        val prevValue: V = search(key) ?: return null       // if key was not in the tree, nothing to delete
         deleteAndBalanceRecursively(root, key)
-        return null         // TODO: DELETE
+
+        return prevValue
     }
 
     private fun deleteAndBalanceRecursively(node: AVLNode<K, V>?, key: K): AVLNode<K, V>? {

--- a/lib/src/main/kotlin/tsl/trees/AVLTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/AVLTree.kt
@@ -1,7 +1,6 @@
 package tsl.trees
 
 import tsl.nodes.AVLNode
-import tsl.nodes.RBNode
 
 import kotlin.math.max
 

--- a/lib/src/main/kotlin/tsl/trees/AVLTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/AVLTree.kt
@@ -5,11 +5,11 @@ import tsl.nodes.AVLNode
 import kotlin.math.max
 
 class AVLTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, AVLNode<K, V>>() {
-
-    // TODO: add return of replaced value or null if key was not present in the tree
     override fun insert(key: K, value: V): V? {
+        val prevValue = search(key)               // null if key wasn't in the tree
         insertAndBalanceRecursively(root, key, value)
-        return value        // TODO: DELETE
+
+        return prevValue
     }
 
     private fun insertAndBalanceRecursively(node: AVLNode<K, V>?, key: K, value: V): AVLNode<K, V>? {

--- a/lib/src/main/kotlin/tsl/trees/AVLTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/AVLTree.kt
@@ -1,14 +1,16 @@
 package tsl.trees
 
 import tsl.nodes.AVLNode
+import tsl.nodes.RBNode
 
 import kotlin.math.max
 
 class AVLTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, AVLNode<K, V>>() {
 
     // TODO: add return of replaced value or null if key was not present in the tree
-    override fun insert(key: K, value: V) {
+    override fun insert(key: K, value: V): V? {
         insertAndBalanceRecursively(root, key, value)
+        return value        // TODO: DELETE
     }
 
     private fun insertAndBalanceRecursively(node: AVLNode<K, V>?, key: K, value: V): AVLNode<K, V>? {
@@ -18,24 +20,22 @@ class AVLTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, AVLNode<K, V>>() 
         }
         if (node == null) return AVLNode(key, value)
 
-        if (key == node.key) return node
-        else if (key < node.key) {
+        if (key < node.key) {
             node.leftChild = insertAndBalanceRecursively(node.leftChild, key, value)
         } else if (key > node.key) {
             node.rightChild = insertAndBalanceRecursively(node.rightChild, key, value)
-        }
+        } else return node
 
         updateHeight(node)
 
-        val balanceFactor = getHeight(node.rightChild) - getHeight(node.leftChild)
+        val balanceFactor = getBalanceFactor(node)
 
-        // rotate if node is not balanced
         if (balanceFactor < -1) {               // *-right cases
             node.leftChild?.let {
                 if (key > it.key) node.leftChild = rotateLeft(it)       // left-right case
                 return rotateRight(node)
             }
-        } else if (balanceFactor > 1) {           // *-left cases
+        } else if (balanceFactor > 1) {         // *-left cases
             node.rightChild?.let {
                 if (key < it.key) node.rightChild = rotateRight(it)     // right-left case
                 return rotateLeft(node)
@@ -58,7 +58,7 @@ class AVLTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, AVLNode<K, V>>() 
         return newUpperNode
     }
 
-    private fun rotateLeft(oldUpperNode: AVLNode<K, V>): AVLNode<K, V>? {
+    private fun rotateLeft(oldUpperNode: AVLNode<K, V>): AVLNode<K, V> {
         val newUpperNode = oldUpperNode.rightChild ?: return oldUpperNode
         oldUpperNode.rightChild = newUpperNode.leftChild
         newUpperNode.leftChild = oldUpperNode
@@ -76,9 +76,58 @@ class AVLTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, AVLNode<K, V>>() 
         return node.height
     }
 
+    private fun getBalanceFactor(node: AVLNode<K, V>): Int {
+        return getHeight(node.rightChild) - getHeight(node.leftChild)
+    }
+
     private fun getHeight(node: AVLNode<K, V>?) = node?.height ?: -1
 
-    override fun delete(key: K) {
-        TODO("implement node deletion method")
+    override fun delete(key: K): V? {
+        deleteAndBalanceRecursively(root, key)
+        return null         // TODO: DELETE
+    }
+
+    private fun deleteAndBalanceRecursively(node: AVLNode<K, V>?, key: K): AVLNode<K, V>? {
+        if (node == null) return null
+
+        if (key < node.key) {
+            node.leftChild = deleteAndBalanceRecursively(node.leftChild, key)
+        } else if (key > node.key) {
+            node.rightChild = deleteAndBalanceRecursively(node.rightChild, key)
+        } else {
+            if (node.leftChild == null || node.rightChild == null) {        // case of 0 or 1 child
+                val temp = node.leftChild ?: node.rightChild
+                return temp
+            } else {                                                        // case of 2 children
+                var successor = node.rightChild
+                while (successor?.leftChild != null) {
+                    successor = successor.leftChild
+                }
+                if (successor != null) {
+                    node.key = successor.key
+                    node.value = successor.value
+                    val temp = deleteAndBalanceRecursively(node.rightChild, successor.key)
+                    if (temp != null) node.rightChild = temp
+                }
+            }
+        }
+
+        updateHeight(node)
+
+        val balanceFactor = getBalanceFactor(node)
+
+        if (balanceFactor < -1) {               // *-right cases
+            node.leftChild?.let {
+                if (getBalanceFactor(it) > 0) node.leftChild = rotateLeft(it)       // left-right case
+                return rotateRight(node)
+            }
+        } else if (balanceFactor > 1) {         // *-left cases
+            node.rightChild?.let {
+                if (getBalanceFactor(it) < 0) node.rightChild = rotateRight(it)     // right-left case
+                return rotateLeft(node)
+            }
+        }
+
+        return node
     }
 }

--- a/lib/src/main/kotlin/tsl/trees/AbstractBinaryTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/AbstractBinaryTree.kt
@@ -3,7 +3,7 @@ package tsl.trees
 import tsl.nodes.AbstractNode
 
 abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N>> {
-    internal var root: N? = null
+    protected var root: N? = null
 
     fun search(key: K): V? {
         return searchNode(root, key)
@@ -16,9 +16,9 @@ abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N
         return if (node?.key == key) {
             node.value
         } else if (node == null) {
-            return null
+            null
         } else {
-            if (key < (node.key)) {
+            if (key < node.key) {
                 searchNode(node.leftChild, key)
             } else {
                 searchNode(node.rightChild, key)


### PR DESCRIPTION
Added deletion method that uses recursion to delete a node and then balance the tree.
It returns null if the key was not in the tree, otherwise it returns the value of a deleted node.

Fixed return value for insertion method: return null if key was not in the tree, otherwise replace old value with the new value and return old value.

Change visibility modifier of root in Abstract binary tree from internal to private.

+Did small refactor