### PR TITLE
Implement iterable interface for binary trees, fix visibility and refactor

### DIFF
--- a/lib/src/main/kotlin/tsl/iterator/BinaryTreeIterator.kt
+++ b/lib/src/main/kotlin/tsl/iterator/BinaryTreeIterator.kt
@@ -4,13 +4,25 @@ import tsl.nodes.AbstractNode
 import tsl.trees.AbstractBinaryTree
 
 internal class BinaryTreeIterator<K : Comparable<K>, V, N: AbstractNode<K, V, N>>
-    (tree: AbstractBinaryTree<K, V, N>): Iterator<Pair<K, V>>  {
+    (tree: AbstractBinaryTree<K, V, N>): Iterator<Pair<K?, V?>>  {
+
+    private var stack = ArrayDeque<N>()
+    private var currentNode: N? = tree.root
 
     override fun hasNext(): Boolean {
-        TODO("Not yet implemented")
+        return (!stack.isEmpty() || currentNode != null)
     }
 
-    override fun next(): Pair<K, V> {
-        TODO("Not yet implemented")
+    override fun next(): Pair<K?, V?> {
+        while (currentNode != null) {
+            currentNode?.let { stack.addLast(it) }
+            currentNode = currentNode?.leftChild
+        }
+
+        currentNode = stack.removeLast()
+        val nextNode = currentNode
+        currentNode = currentNode?.rightChild
+
+        return Pair(nextNode?.key, nextNode?.value)
     }
 }

--- a/lib/src/main/kotlin/tsl/iterator/BinaryTreeIterator.kt
+++ b/lib/src/main/kotlin/tsl/iterator/BinaryTreeIterator.kt
@@ -1,0 +1,16 @@
+package tsl.iterator
+
+import tsl.nodes.AbstractNode
+import tsl.trees.AbstractBinaryTree
+
+internal class BinaryTreeIterator<K : Comparable<K>, V, N: AbstractNode<K, V, N>>
+    (tree: AbstractBinaryTree<K, V, N>): Iterator<Pair<K, V>>  {
+
+    override fun hasNext(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun next(): Pair<K, V> {
+        TODO("Not yet implemented")
+    }
+}

--- a/lib/src/main/kotlin/tsl/nodes/AVLNode.kt
+++ b/lib/src/main/kotlin/tsl/nodes/AVLNode.kt
@@ -1,5 +1,5 @@
 package tsl.nodes
 
 class AVLNode<K : Comparable<K>, V>(key: K, value: V) : AbstractNode<K, V, AVLNode<K, V>>(key, value) {
-    var height = 0
+    internal var height = 0
 }

--- a/lib/src/main/kotlin/tsl/trees/AVLTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/AVLTree.kt
@@ -6,10 +6,9 @@ import kotlin.math.max
 
 class AVLTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, AVLNode<K, V>>() {
     override fun insert(key: K, value: V): V? {
-        val prevValue = search(key)               // null if key wasn't in the tree
+        val replacedValue = search(key)        // null if key isn't in the tree
         insertAndBalanceRecursively(root, key, value)
-
-        return prevValue
+        return replacedValue
     }
 
     private fun insertAndBalanceRecursively(node: AVLNode<K, V>?, key: K, value: V): AVLNode<K, V>? {
@@ -29,14 +28,68 @@ class AVLTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, AVLNode<K, V>>() 
 
         val balanceFactor = getBalanceFactor(node)
 
-        if (balanceFactor < -1) {               // *-right cases
+        if (balanceFactor < -1) {                       // right cases
             node.leftChild?.let {
-                if (key > it.key) node.leftChild = rotateLeft(it)       // left-right case
+                if (key > it.key) {
+                    node.leftChild = rotateLeft(it)     // left-right case
+                }
                 return rotateRight(node)
             }
-        } else if (balanceFactor > 1) {         // *-left cases
+        } else if (balanceFactor > 1) {                 // left cases
             node.rightChild?.let {
-                if (key < it.key) node.rightChild = rotateRight(it)     // right-left case
+                if (key < it.key) {
+                    node.rightChild = rotateRight(it)   // right-left case
+                }
+                return rotateLeft(node)
+            }
+        }
+
+        return node
+    }
+
+    override fun delete(key: K): V? {
+        val deletedValue: V = search(key) ?: return null    // if key isn't in the tree, there's nothing to delete
+        deleteAndBalanceRecursively(root, key)
+        return deletedValue
+    }
+
+    private fun deleteAndBalanceRecursively(node: AVLNode<K, V>?, key: K): AVLNode<K, V>? {
+        if (node == null) return null           // node to be deleted was not found
+
+        if (key < node.key) {
+            node.leftChild = deleteAndBalanceRecursively(node.leftChild, key)
+        } else if (key > node.key) {
+            node.rightChild = deleteAndBalanceRecursively(node.rightChild, key)
+        } else if (node.leftChild == null || node.rightChild == null) {     // if node to be deleted has 0 or 1 child
+            return node.leftChild ?: node.rightChild
+        } else {                                                            // if node to be deleted has 2 children
+            val successor = getMinNode(node.rightChild)
+            if (successor != null) {
+                node.key = successor.key
+                node.value = successor.value
+
+                // delete successor node from tree
+                val temp = deleteAndBalanceRecursively(node.rightChild, successor.key)
+                if (temp != null) node.rightChild = temp
+            }
+        }
+
+        updateHeight(node)
+
+        val balanceFactor = getBalanceFactor(node)
+
+        if (balanceFactor < -1) {                       // right rotation cases
+            node.leftChild?.let {
+                if (getBalanceFactor(it) > 0) {         // left-right case
+                    node.leftChild = rotateLeft(it)
+                }
+                return rotateRight(node)
+            }
+        } else if (balanceFactor > 1) {                 // left rotation cases
+            node.rightChild?.let {
+                if (getBalanceFactor(it) < 0) {         // right-left case
+                    node.rightChild = rotateRight(it)
+                }
                 return rotateLeft(node)
             }
         }
@@ -49,7 +102,7 @@ class AVLTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, AVLNode<K, V>>() 
         oldUpperNode.leftChild = newUpperNode.rightChild
         newUpperNode.rightChild = oldUpperNode
 
-        if (root == oldUpperNode) root = newUpperNode      // if root was rotated, set new root
+        if (root == oldUpperNode) root = newUpperNode       // if root was rotated, set new root
 
         updateHeight(oldUpperNode)
         updateHeight(newUpperNode)
@@ -62,7 +115,7 @@ class AVLTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, AVLNode<K, V>>() 
         oldUpperNode.rightChild = newUpperNode.leftChild
         newUpperNode.leftChild = oldUpperNode
 
-        if (root == oldUpperNode) root = newUpperNode      // if root was rotated, set new root
+        if (root == oldUpperNode) root = newUpperNode       // if root was rotated, set new root
 
         updateHeight(oldUpperNode)
         updateHeight(newUpperNode)
@@ -79,56 +132,7 @@ class AVLTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, AVLNode<K, V>>() 
         return getHeight(node.rightChild) - getHeight(node.leftChild)
     }
 
-    private fun getHeight(node: AVLNode<K, V>?) = node?.height ?: -1
-
-    override fun delete(key: K): V? {
-        val prevValue: V = search(key) ?: return null       // if key was not in the tree, nothing to delete
-        deleteAndBalanceRecursively(root, key)
-
-        return prevValue
-    }
-
-    private fun deleteAndBalanceRecursively(node: AVLNode<K, V>?, key: K): AVLNode<K, V>? {
-        if (node == null) return null
-
-        if (key < node.key) {
-            node.leftChild = deleteAndBalanceRecursively(node.leftChild, key)
-        } else if (key > node.key) {
-            node.rightChild = deleteAndBalanceRecursively(node.rightChild, key)
-        } else {
-            if (node.leftChild == null || node.rightChild == null) {        // case of 0 or 1 child
-                val temp = node.leftChild ?: node.rightChild
-                return temp
-            } else {                                                        // case of 2 children
-                var successor = node.rightChild
-                while (successor?.leftChild != null) {
-                    successor = successor.leftChild
-                }
-                if (successor != null) {
-                    node.key = successor.key
-                    node.value = successor.value
-                    val temp = deleteAndBalanceRecursively(node.rightChild, successor.key)
-                    if (temp != null) node.rightChild = temp
-                }
-            }
-        }
-
-        updateHeight(node)
-
-        val balanceFactor = getBalanceFactor(node)
-
-        if (balanceFactor < -1) {               // *-right cases
-            node.leftChild?.let {
-                if (getBalanceFactor(it) > 0) node.leftChild = rotateLeft(it)       // left-right case
-                return rotateRight(node)
-            }
-        } else if (balanceFactor > 1) {         // *-left cases
-            node.rightChild?.let {
-                if (getBalanceFactor(it) < 0) node.rightChild = rotateRight(it)     // right-left case
-                return rotateLeft(node)
-            }
-        }
-
-        return node
+    private fun getHeight(node: AVLNode<K, V>?): Int {
+        return node?.height ?: -1
     }
 }

--- a/lib/src/main/kotlin/tsl/trees/AbstractBinaryTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/AbstractBinaryTree.kt
@@ -3,8 +3,8 @@ package tsl.trees
 import tsl.nodes.AbstractNode
 import tsl.iterator.BinaryTreeIterator
 
-abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N>> : Iterable<Pair<K, V>> {
-    protected var root: N? = null
+abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N>>: Iterable<Pair<K?, V?>> {
+    internal var root: N? = null
 
     abstract fun delete(key: K): V?
 
@@ -48,7 +48,7 @@ abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N
         else  getMaxNode(node.leftChild)
     }
 
-    override fun iterator(): Iterator<Pair<K, V>> {
+    override fun iterator(): Iterator<Pair<K?, V?>> {
         return BinaryTreeIterator(this)
     }
 }

--- a/lib/src/main/kotlin/tsl/trees/AbstractBinaryTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/AbstractBinaryTree.kt
@@ -1,8 +1,9 @@
 package tsl.trees
 
 import tsl.nodes.AbstractNode
+import tsl.iterator.BinaryTreeIterator
 
-abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N>> {
+abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N>>: Iterable<Pair<K, V>> {
     protected var root: N? = null
 
     abstract fun delete(key: K): V?
@@ -49,5 +50,9 @@ abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N
         if (node == null) return null
         if (node.leftChild == null) return node
         return getMinNode(node.leftChild)
+    }
+
+    override fun iterator(): Iterator<Pair<K, V>> {
+        return BinaryTreeIterator(this)
     }
 }

--- a/lib/src/main/kotlin/tsl/trees/AbstractBinaryTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/AbstractBinaryTree.kt
@@ -3,7 +3,7 @@ package tsl.trees
 import tsl.nodes.AbstractNode
 import tsl.iterator.BinaryTreeIterator
 
-abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N>>: Iterable<Pair<K, V>> {
+abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N>> : Iterable<Pair<K, V>> {
     protected var root: N? = null
 
     abstract fun delete(key: K): V?
@@ -17,13 +17,11 @@ abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N
         return searchNode(root, key)?.value
     }
 
-    protected fun searchNode(node: AbstractNode<K, V, N>?, key: K): AbstractNode<K, V, N>? {
-        return if (node?.key == key) node
-        else if (node == null) null
-        else {
-            if (key < node.key) searchNode(node.leftChild, key)
-            else searchNode(node.rightChild, key)
-        }
+    private fun searchNode(node: AbstractNode<K, V, N>?, key: K): AbstractNode<K, V, N>? {
+        return if (node == null) null
+        else if (node.key == key) node
+        else if (key < node.key) searchNode(node.leftChild, key)
+        else searchNode(node.rightChild, key)
     }
 
     fun clear() {
@@ -31,25 +29,23 @@ abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N
     }
 
     fun getMinKey(): K? {
-        if (root == null) return null
         return getMinNode(root)?.key
     }
 
     fun getMaxKey(): K? {
-        if (root == null) return null
         return getMaxNode(root)?.key
     }
 
-    protected fun getMinNode(node: AbstractNode<K, V, N>?): AbstractNode<K, V, N>? {
-        if (node == null) return null
-        if (node.leftChild == null) return node
-        return getMinNode(node.leftChild)
+    protected fun getMinNode(node: N?): N? {
+        return if (node == null) null
+        else if (node.leftChild == null) node
+        else  getMinNode(node.leftChild)
     }
 
-    protected fun getMaxNode(node: AbstractNode<K, V, N>?): AbstractNode<K, V, N>? {
-        if (node == null) return null
-        if (node.leftChild == null) return node
-        return getMinNode(node.leftChild)
+    private fun getMaxNode(node: N?): N? {
+        return if (node == null) null
+        else if (node.leftChild == null) node
+        else  getMaxNode(node.leftChild)
     }
 
     override fun iterator(): Iterator<Pair<K, V>> {

--- a/lib/src/main/kotlin/tsl/trees/BSTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/BSTree.kt
@@ -11,7 +11,9 @@ class BSTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, BSTNode<K, V>>() {
 			root = nodeToInsert
 			return null
 		}
-		var currentNode: BSTNode<K, V>? = root
+
+		var currentNode = root
+
 		while (currentNode != null) {
 			if (nodeToInsert.key == currentNode.key) {
 				val oldValue = currentNode.value


### PR DESCRIPTION
Made Abstract binary tree iterable by key/value pairs, impemented iterator. 
Changed variable names, added clear comments, reorganized AVL tree class.
Changed visibility modifier of height and root fields to internal.