### PR TITLE
Correct work of 'delete' and 'insert' methods in RB tree, rectify the balance and fixup methods. Make some refactoring.

### DIFF
--- a/lib/src/main/kotlin/tsl/nodes/RBNode.kt
+++ b/lib/src/main/kotlin/tsl/nodes/RBNode.kt
@@ -18,41 +18,5 @@ class RBNode<K : Comparable<K>, V>(key: K, value: V) : AbstractNode<K, V, RBNode
             node2.color = node1color
         }
     }
-
-    internal fun rotateLeft() {
-        val rightChild = this.rightChild ?: return
-        val dad = this.parent
-
-        this.switchColor(rightChild)
-        rightChild.leftChild?.parent = this
-        this.rightChild = rightChild.leftChild
-        rightChild.leftChild = this
-
-        when {
-            this == dad?.leftChild -> dad.leftChild = rightChild
-            this == dad?.rightChild -> dad.rightChild = rightChild
-        }
-
-        this.parent = rightChild
-        rightChild.parent = dad
-    }
-
-    internal fun rotateRight() {
-        val leftChild = this.leftChild ?: return
-        val dad = this.parent
-
-        this.switchColor(leftChild)
-        leftChild.rightChild?.parent = this
-        this.leftChild = leftChild.rightChild
-        leftChild.rightChild = this
-
-        when {
-            this == dad?.leftChild -> dad.leftChild = leftChild
-            this == dad?.rightChild -> dad.rightChild = leftChild
-        }
-
-        this.parent = leftChild
-        leftChild.parent = dad
-    }
 }
 

--- a/lib/src/main/kotlin/tsl/trees/AbstractBinaryTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/AbstractBinaryTree.kt
@@ -17,7 +17,7 @@ abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N
         return searchNode(root, key)?.value
     }
 
-    private fun searchNode(node: N?, key: K): N? {
+    protected fun searchNode(node: AbstractNode<K, V, N>?, key: K): AbstractNode<K, V, N>? {
         return if (node == null) null
         else if (node.key == key) node
         else if (key < node.key) searchNode(node.leftChild, key)
@@ -42,10 +42,10 @@ abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N
         else  getMinNode(node.leftChild)
     }
 
-    private fun getMaxNode(node: N?): N? {
+    protected fun getMaxNode(node: N?): N? {
         return if (node == null) null
-        else if (node.leftChild == null) node
-        else  getMaxNode(node.leftChild)
+        else if (node.rightChild == null) node
+        else  getMaxNode(node.rightChild)
     }
 
     override fun iterator(): Iterator<Pair<K?, V?>> {

--- a/lib/src/main/kotlin/tsl/trees/AbstractBinaryTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/AbstractBinaryTree.kt
@@ -17,7 +17,7 @@ abstract class AbstractBinaryTree<K : Comparable<K>, V, N : AbstractNode<K, V, N
         return searchNode(root, key)?.value
     }
 
-    private fun searchNode(node: AbstractNode<K, V, N>?, key: K): AbstractNode<K, V, N>? {
+    private fun searchNode(node: N?, key: K): N? {
         return if (node == null) null
         else if (node.key == key) node
         else if (key < node.key) searchNode(node.leftChild, key)

--- a/lib/src/main/kotlin/tsl/trees/RBTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/RBTree.kt
@@ -99,7 +99,7 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
     }
 
     override fun delete(key: K): V? {
-        root = deleteNode(root, key)
+        root = deleteNode(key)
         root?.color = RBNode.Color.Black // ensure the root is black after deletion
         return null
     }
@@ -108,13 +108,11 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
      * Deletes a node with the specified key from the Red\-Black Tree\.
      * If the node with the key is found, it is removed from the tree and the tree is rebalanced if necessary\.
      *
-     * @param node The root node of the Red\-Black Tree\.
      * @param key The key of the node to be deleted\.
      * @return The new root node of the Red\-Black Tree after deletion\.
      */
 
     private fun deleteNode(
-        node: RBNode<K, V>?,
         key: K,
     ): RBNode<K, V>? {
         var current: RBNode<K, V>? = searchNode(root, key) as RBNode<K, V>?

--- a/lib/src/main/kotlin/tsl/trees/RBTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/RBTree.kt
@@ -146,66 +146,70 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
         return newRoot
     }
 
-    private fun fixAfterDeletion(currentNode: RBNode<K, V>?): RBNode<K, V>? {
+    private fun fixAfterDeletion(currentDeletingNode: RBNode<K, V>?): RBNode<K, V>? {
         var fixedRoot = root
-        var node = currentNode
+        var currentNode = currentDeletingNode
+        // currentNode - variable that is used to perform various operations and control the loop of fixing the tree.
 
-        while (node != root && node?.color == RBNode.Color.Black) {
-            if (node == node.parent?.leftChild) {
-                var currentSibling: RBNode<K, V>? = node.parent?.rightChild
+        while (currentNode != root && currentNode?.color == RBNode.Color.Black) {
+            if (currentNode == currentNode.parent?.leftChild) {
+                var currentSibling: RBNode<K, V>? = currentNode.parent?.rightChild
                 if (currentSibling?.color == RBNode.Color.Red) { // 1st case "currentSibling is red"
                     currentSibling.color = RBNode.Color.Black
-                    node.parent?.color = RBNode.Color.Red
-                    fixedRoot = rotateLeft(node.parent, fixedRoot)
-                    currentSibling = node.parent?.rightChild  // transfer to other cases
+                    currentNode.parent?.color = RBNode.Color.Red
+                    fixedRoot = rotateLeft(currentNode.parent, fixedRoot)
+                    currentSibling = currentNode.parent?.rightChild  // transfer to other cases
                 }
                 else if (currentSibling?.leftChild?.color == RBNode.Color.Black && currentSibling.rightChild?.color == RBNode.Color.Black) {
                     // 2nd case "currentSibling and its children are black"
                     currentSibling.color = RBNode.Color.Red
-                    node = node.parent
+                    currentNode = currentNode.parent
                 } else {
                     if (currentSibling?.rightChild?.color == RBNode.Color.Black) {
                         // 3rd case "like 2nd but the left child is red"
                         (currentSibling.leftChild )?.color = RBNode.Color.Black
                         currentSibling.color = RBNode.Color.Red
                         fixedRoot = rotateRight(currentSibling, fixedRoot)
-                        currentSibling = node.parent?.rightChild
+                        currentSibling = currentNode.parent?.rightChild
                     }
-                    currentSibling?.color = node.parent?.color!! // 4th case "black currentSibling, right child is black'
-                    node.parent?.color = RBNode.Color.Black
+                    // 4th case "black currentSibling, right child is black'
+                    currentSibling?.color = currentNode.parent?.color ?: RBNode.Color.Black
+                    currentNode.parent?.color = RBNode.Color.Black
                     currentSibling?.rightChild?.color = RBNode.Color.Black
-                    fixedRoot = rotateLeft(node.parent, fixedRoot)
-                    node = fixedRoot
+                    fixedRoot = rotateLeft(currentNode.parent, fixedRoot)
+                    currentNode = fixedRoot
                 }
             } else {
-                var currentSibling: RBNode<K, V>? = node.parent?.leftChild
+                var currentSibling: RBNode<K, V>? = currentNode.parent?.leftChild
                 if (currentSibling?.color == RBNode.Color.Red) {
                     // 1st case "red currentSibling"
                     currentSibling.color = RBNode.Color.Black
-                    node.parent?.color = RBNode.Color.Red
-                    fixedRoot = rotateRight(node.parent, fixedRoot)
-                    currentSibling = node.parent?.leftChild  // transfer to other cases
+                    currentNode.parent?.color = RBNode.Color.Red
+                    fixedRoot = rotateRight(currentNode.parent, fixedRoot)
+                    currentSibling = currentNode.parent?.leftChild  // transfer to other cases
                 }
                 // 2nd case "currentSibling and its children are black"
                 if (currentSibling?.leftChild?.color == RBNode.Color.Black && currentSibling.rightChild?.color == RBNode.Color.Black) {
                     currentSibling.color = RBNode.Color.Red
-                    node = node.parent
+                    currentNode = currentNode.parent
                 } else {
-                    if (currentSibling?.leftChild?.color == RBNode.Color.Black) { // 3rd case "like 2nd but the right child is red"
+                    // 3rd case "like 2nd but the right child is red"
+                    if (currentSibling?.leftChild?.color == RBNode.Color.Black) {
                         currentSibling.rightChild?.color = RBNode.Color.Black
                         currentSibling.color = RBNode.Color.Red
                         fixedRoot = rotateLeft(currentSibling, fixedRoot)
-                        currentSibling = node.parent?.leftChild
+                        currentSibling = currentNode.parent?.leftChild
                     }
-                    currentSibling?.color = node.parent?.color!! // 4th case "black currentSibling, left child is red'
-                    (node.parent)?.color = RBNode.Color.Black
+                    // 4th case "black currentSibling, left child is red'
+                    currentSibling?.color = currentNode.parent?.color ?: RBNode.Color.Black
+                    (currentNode.parent)?.color = RBNode.Color.Black
                     (currentSibling?.leftChild)?.color = RBNode.Color.Black
-                    fixedRoot = rotateRight(node.parent, fixedRoot)
-                    node = fixedRoot
+                    fixedRoot = rotateRight(currentNode.parent, fixedRoot)
+                    currentNode = fixedRoot
                 }
             }
         }
-        node?.color = RBNode.Color.Black
+        currentNode?.color = RBNode.Color.Black
         return fixedRoot
     }
 }

--- a/lib/src/main/kotlin/tsl/trees/RBTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/RBTree.kt
@@ -44,6 +44,14 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
         return null
     }
 
+    /**
+     * This function is used to balance the red-black tree node after insertion.
+     * It checks the colors of the parent and grandparent nodes to determine the rotations needed for balancing.
+     * The function alternates between left and right rotations to maintain the balance of the tree.
+     * The root variable is updated to maintain the correct root node after balancing.
+     * @param RBNode-typed node
+     */
+
     private fun balanceNode(node: RBNode<K, V>?) {
         var newNode = node
         var uncle: RBNode<K, V>?
@@ -97,6 +105,15 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
         return null
     }
 
+    /**
+    * Deletes a node with the specified key from the Red\-Black Tree\.
+    * If the node with the key is found, it is removed from the tree and the tree is rebalanced if necessary\.
+    *
+    * @param node The root node of the Red\-Black Tree\.
+    * @param key The key of the node to be deleted\.
+    * @return The new root node of the Red\-Black Tree after deletion\.
+    */
+
     private fun deleteNode(node: RBNode<K, V>?, key: K): RBNode<K, V>? {
         var current: RBNode<K, V>? = searchNode(root, key) as RBNode<K, V>?
         if (current == null) return root
@@ -139,6 +156,16 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
         }
         return newRoot
     }
+
+    /**
+     * This function is used to fix the red-black tree structure after a node deletion to ensure that the red-black
+     * properties of the tree are maintained.
+     * It iterates through the nodes and performs rotations and recoloring based on the cases derived from the sibling
+     * and its children's colors to balance the tree.
+     *
+     * @param currentNode The node that needs fixing after deletion
+     * @return The root of the tree after fixing the structure to maintain the red-black properties
+     */
 
     private fun fixAfterDeletion(currentDeletingNode: RBNode<K, V>?): RBNode<K, V>? {
         var fixedRoot = root

--- a/lib/src/main/kotlin/tsl/trees/RBTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/RBTree.kt
@@ -47,54 +47,48 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
     private fun balanceNode(node: RBNode<K, V>?) {
         var newNode = node
         var uncle: RBNode<K, V>?
-        while (newNode?.parent?.color == RBNode.Color.Red) {
+        var newRoot = root
+        while (newNode?.parent?.color == RBNode.Color.Red && newNode.parent != newRoot) {
+            var currentParent: RBNode<K, V>? = newNode.parent
+            val currentGrandParent: RBNode<K, V>? = currentParent?.parent
             if (newNode.parent == newNode.parent?.parent?.leftChild) {
-                uncle = newNode.parent?.parent?.rightChild
+                uncle = currentParent?.parent?.rightChild
 
-                when {
-                    uncle?.color == RBNode.Color.Red -> {
-                        newNode.parent?.color = RBNode.Color.Black
-                        uncle.color = RBNode.Color.Black
-                        newNode.parent?.parent?.color = RBNode.Color.Red
-                        newNode = newNode.parent?.parent
+                if (uncle?.color == RBNode.Color.Red) {
+                    currentParent?.color = RBNode.Color.Black
+                    uncle.color = RBNode.Color.Black
+                    currentGrandParent?.color = RBNode.Color.Red
+                    newNode = currentGrandParent
+                } else {
+                    if (newNode == newNode.parent?.rightChild) {
+                        newNode = currentParent
+                        newRoot = rotateLeft(newNode, newRoot)
+                        currentParent = newNode?.parent
                     }
-
-                    newNode == newNode.parent?.rightChild -> {
-                        newNode = newNode.parent
-                        if (newNode?.parent?.parent == null) root = newNode?.parent
-                        newNode?.rotateLeft()
-                    }
-
-                    newNode == newNode.parent?.leftChild -> {
-                        if (newNode.parent?.parent?.parent == null) root = newNode.parent
-                        newNode.parent?.parent?.rotateRight()
-                    }
+                    currentParent?.color = RBNode.Color.Black
+                    currentGrandParent?.color = RBNode.Color.Red
+                    newRoot = rotateRight(currentGrandParent, newRoot)
                 }
-            } else {
+            } else if (currentParent == currentGrandParent?.rightChild) {
                 uncle = newNode.parent?.parent?.leftChild
-
-                when {
-                    uncle?.color == RBNode.Color.Red -> {
-                        newNode.parent?.color = RBNode.Color.Black
-                        uncle.color = RBNode.Color.Black
-                        newNode.parent?.parent?.color = RBNode.Color.Red
-                        newNode = newNode.parent?.parent
+                if (uncle?.color == RBNode.Color.Red) {
+                    currentParent?.color = RBNode.Color.Black
+                    uncle.color = RBNode.Color.Black
+                    currentGrandParent?.color = RBNode.Color.Red
+                    newNode = currentGrandParent
+                } else {
+                    if (newNode == currentParent?.leftChild) {
+                        newNode = currentParent
+                        newRoot = rotateRight(newNode, newRoot)
+                        currentParent = newNode.parent
                     }
-
-                    newNode == newNode.parent?.leftChild -> {
-                        newNode = newNode.parent
-                        if (newNode?.parent?.parent == null) root = newNode?.parent
-                        newNode?.rotateRight()
-                    }
-
-                    newNode == newNode.parent?.rightChild -> {
-                        if (newNode.parent?.parent?.parent == null) root = newNode.parent
-                        newNode.parent?.parent?.rotateLeft()
-                    }
+                    currentParent?.color = RBNode.Color.Black
+                    currentGrandParent?.color = RBNode.Color.Red
+                    newRoot = rotateLeft(currentGrandParent, newRoot)
                 }
             }
         }
-        root?.color = RBNode.Color.Black
+        root = newRoot
     }
 
     override fun delete(key: K): V? {

--- a/lib/src/main/kotlin/tsl/trees/RBTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/RBTree.kt
@@ -145,4 +145,67 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
         }
         return newRoot
     }
+
+    private fun fixAfterDeletion(currentNode: RBNode<K, V>?): RBNode<K, V>? {
+        var fixedRoot = root
+        var node = currentNode
+
+        while (node != root && node?.color == RBNode.Color.Black) {
+            if (node == node.parent?.leftChild) {
+                var currentSibling: RBNode<K, V>? = node.parent?.rightChild
+                if (currentSibling?.color == RBNode.Color.Red) { // 1st case "currentSibling is red"
+                    currentSibling.color = RBNode.Color.Black
+                    node.parent?.color = RBNode.Color.Red
+                    fixedRoot = rotateLeft(node.parent, fixedRoot)
+                    currentSibling = node.parent?.rightChild  // transfer to other cases
+                }
+                else if (currentSibling?.leftChild?.color == RBNode.Color.Black && currentSibling.rightChild?.color == RBNode.Color.Black) {
+                    // 2nd case "currentSibling and its children are black"
+                    currentSibling.color = RBNode.Color.Red
+                    node = node.parent
+                } else {
+                    if (currentSibling?.rightChild?.color == RBNode.Color.Black) {
+                        // 3rd case "like 2nd but the left child is red"
+                        (currentSibling.leftChild )?.color = RBNode.Color.Black
+                        currentSibling.color = RBNode.Color.Red
+                        fixedRoot = rotateRight(currentSibling, fixedRoot)
+                        currentSibling = node.parent?.rightChild
+                    }
+                    currentSibling?.color = node.parent?.color!! // 4th case "black currentSibling, right child is black'
+                    node.parent?.color = RBNode.Color.Black
+                    currentSibling?.rightChild?.color = RBNode.Color.Black
+                    fixedRoot = rotateLeft(node.parent, fixedRoot)
+                    node = fixedRoot
+                }
+            } else {
+                var currentSibling: RBNode<K, V>? = node.parent?.leftChild
+                if (currentSibling?.color == RBNode.Color.Red) {
+                    // 1st case "red currentSibling"
+                    currentSibling.color = RBNode.Color.Black
+                    node.parent?.color = RBNode.Color.Red
+                    fixedRoot = rotateRight(node.parent, fixedRoot)
+                    currentSibling = node.parent?.leftChild  // transfer to other cases
+                }
+                // 2nd case "currentSibling and its children are black"
+                if (currentSibling?.leftChild?.color == RBNode.Color.Black && currentSibling.rightChild?.color == RBNode.Color.Black) {
+                    currentSibling.color = RBNode.Color.Red
+                    node = node.parent
+                } else {
+                    if (currentSibling?.leftChild?.color == RBNode.Color.Black) { // 3rd case "like 2nd but the right child is red"
+                        currentSibling.rightChild?.color = RBNode.Color.Black
+                        currentSibling.color = RBNode.Color.Red
+                        fixedRoot = rotateLeft(currentSibling, fixedRoot)
+                        currentSibling = node.parent?.leftChild
+                    }
+                    currentSibling?.color = node.parent?.color!! // 4th case "black currentSibling, left child is red'
+                    (node.parent)?.color = RBNode.Color.Black
+                    (currentSibling?.leftChild)?.color = RBNode.Color.Black
+                    fixedRoot = rotateRight(node.parent, fixedRoot)
+                    node = fixedRoot
+                }
+            }
+        }
+        node?.color = RBNode.Color.Black
+        return fixedRoot
+    }
 }

--- a/lib/src/main/kotlin/tsl/trees/RBTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/RBTree.kt
@@ -61,7 +61,6 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
             val currentGrandParent: RBNode<K, V>? = currentParent?.parent
             if (newNode.parent == newNode.parent?.parent?.leftChild) {
                 uncle = currentParent?.parent?.rightChild
-
                 if (uncle?.color == RBNode.Color.Red) {
                     currentParent?.color = RBNode.Color.Black
                     uncle.color = RBNode.Color.Black
@@ -106,15 +105,18 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
     }
 
     /**
-    * Deletes a node with the specified key from the Red\-Black Tree\.
-    * If the node with the key is found, it is removed from the tree and the tree is rebalanced if necessary\.
-    *
-    * @param node The root node of the Red\-Black Tree\.
-    * @param key The key of the node to be deleted\.
-    * @return The new root node of the Red\-Black Tree after deletion\.
-    */
+     * Deletes a node with the specified key from the Red\-Black Tree\.
+     * If the node with the key is found, it is removed from the tree and the tree is rebalanced if necessary\.
+     *
+     * @param node The root node of the Red\-Black Tree\.
+     * @param key The key of the node to be deleted\.
+     * @return The new root node of the Red\-Black Tree after deletion\.
+     */
 
-    private fun deleteNode(node: RBNode<K, V>?, key: K): RBNode<K, V>? {
+    private fun deleteNode(
+        node: RBNode<K, V>?,
+        key: K,
+    ): RBNode<K, V>? {
         var current: RBNode<K, V>? = searchNode(root, key) as RBNode<K, V>?
         if (current == null) return root
         var newRoot = root
@@ -127,7 +129,6 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
             }
             current = successor
         }
-
 
         val child = if (current?.leftChild != null) current.leftChild else current?.rightChild
         if (child != null) {
@@ -179,16 +180,16 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
                     currentSibling.color = RBNode.Color.Black
                     currentNode.parent?.color = RBNode.Color.Red
                     fixedRoot = rotateLeft(currentNode.parent, fixedRoot)
-                    currentSibling = currentNode.parent?.rightChild  // transfer to other cases
-                }
-                else if (currentSibling?.leftChild?.color == RBNode.Color.Black && currentSibling.rightChild?.color == RBNode.Color.Black) {
+                    currentSibling = currentNode.parent?.rightChild // transfer to other cases
+                } else if (currentSibling?.leftChild?.color == RBNode.Color.Black
+                    && currentSibling.rightChild?.color == RBNode.Color.Black) {
                     // 2nd case "currentSibling and its children are black"
                     currentSibling.color = RBNode.Color.Red
                     currentNode = currentNode.parent
                 } else {
                     if (currentSibling?.rightChild?.color == RBNode.Color.Black) {
                         // 3rd case "like 2nd but the left child is red"
-                        (currentSibling.leftChild )?.color = RBNode.Color.Black
+                        (currentSibling.leftChild)?.color = RBNode.Color.Black
                         currentSibling.color = RBNode.Color.Red
                         fixedRoot = rotateRight(currentSibling, fixedRoot)
                         currentSibling = currentNode.parent?.rightChild
@@ -207,10 +208,11 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
                     currentSibling.color = RBNode.Color.Black
                     currentNode.parent?.color = RBNode.Color.Red
                     fixedRoot = rotateRight(currentNode.parent, fixedRoot)
-                    currentSibling = currentNode.parent?.leftChild  // transfer to other cases
+                    currentSibling = currentNode.parent?.leftChild // transfer to other cases
                 }
                 // 2nd case "currentSibling and its children are black"
-                if (currentSibling?.leftChild?.color == RBNode.Color.Black && currentSibling.rightChild?.color == RBNode.Color.Black) {
+                if (currentSibling?.leftChild?.color == RBNode.Color.Black
+                    && currentSibling.rightChild?.color == RBNode.Color.Black) {
                     currentSibling.color = RBNode.Color.Red
                     currentNode = currentNode.parent
                 } else {
@@ -233,53 +235,61 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
         currentNode?.color = RBNode.Color.Black
         return fixedRoot
     }
-    private fun rotateRight(node: RBNode<K, V>?, currentRoot: RBNode<K, V>?): RBNode<K, V>? {
-        val temp = node?.leftChild ?: return node // if left child is null, no rotation needed
+
+    private fun rotateRight(
+        nodeToRotate: RBNode<K, V>?,
+        currentRoot: RBNode<K, V>?,
+    ): RBNode<K, V>? {
+        val rightChild = nodeToRotate?.leftChild ?: return nodeToRotate // if left child is null, no rotation needed
         var newRoot = currentRoot
-        temp.parent = node.parent
+        rightChild.parent = nodeToRotate.parent
 
-        if (temp.leftChild != null) {
-            temp.leftChild?.parent = node
+        if (rightChild.leftChild != null) {
+            rightChild.leftChild?.parent = nodeToRotate
         }
-        temp.rightChild = node
-        node.parent = temp
+        rightChild.rightChild = nodeToRotate
+        nodeToRotate.parent = rightChild
 
-        if (temp.parent != null) {
-            if (node == temp.parent?.leftChild) {
-                temp.parent?.leftChild = temp
+        if (rightChild.parent != null) {
+            if (nodeToRotate == rightChild.parent?.leftChild) {
+                rightChild.parent?.leftChild = rightChild
             } else {
-                temp.parent?.rightChild = temp
+                rightChild.parent?.rightChild = rightChild
             }
         } else {
-            root = temp
+            root = rightChild
+            newRoot = rightChild
         }
 
         return newRoot
     }
 
-    private fun rotateLeft(node: RBNode<K, V>?, currentRoot: RBNode<K, V>?): RBNode<K, V>? {
-        val temp = node?.rightChild ?: return node // if right child is null, no rotation needed
+    private fun rotateLeft(
+        nodeToRotate: RBNode<K, V>?,
+        currentRoot: RBNode<K, V>?,
+    ): RBNode<K, V>? {
+        val rightChild = nodeToRotate?.rightChild ?: return nodeToRotate // if right child is null, no rotation needed
         var newRoot = currentRoot
-        temp.parent = node.parent
+        rightChild.parent = nodeToRotate.parent
 
-        node.rightChild = temp.leftChild;
-        if (node.rightChild != null) {
-            node.rightChild?.parent = node;
+        nodeToRotate.rightChild = rightChild.leftChild
+        if (nodeToRotate.rightChild != null) {
+            nodeToRotate.rightChild?.parent = nodeToRotate
         }
 
-        temp.leftChild = node;
-        node.parent = temp;
+        rightChild.leftChild = nodeToRotate
+        nodeToRotate.parent = rightChild
 
-        // temp took over node's place so now its parent should point to temp
-        if (temp.parent != null) {
-            if (node == temp.parent?.leftChild) {
-                temp.parent?.leftChild = temp;
+        // rightChild took over nodeToRotate's place so now its parent should point to rightChild
+        if (rightChild.parent != null) {
+            if (nodeToRotate == rightChild.parent?.leftChild) {
+                rightChild.parent?.leftChild = rightChild
             } else {
-                temp.parent?.rightChild = temp;
+                rightChild.parent?.rightChild = rightChild
             }
         } else {
-            root = temp;
-            newRoot = temp
+            root = rightChild
+            newRoot = rightChild
         }
         return newRoot
     }

--- a/lib/src/main/kotlin/tsl/trees/RBTree.kt
+++ b/lib/src/main/kotlin/tsl/trees/RBTree.kt
@@ -99,7 +99,7 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
 
     override fun delete(key: K): V? {
         root = deleteNode(root, key)
-        root?.color = RBNode.Color.Black // Ensure the root is black after deletion
+        root?.color = RBNode.Color.Black // ensure the root is black after deletion
         return null
     }
 
@@ -211,5 +211,55 @@ class RBTree<K : Comparable<K>, V> : AbstractBinaryTree<K, V, RBNode<K, V>>() {
         }
         currentNode?.color = RBNode.Color.Black
         return fixedRoot
+    }
+    private fun rotateRight(node: RBNode<K, V>?, currentRoot: RBNode<K, V>?): RBNode<K, V>? {
+        val temp = node?.leftChild ?: return node // if left child is null, no rotation needed
+        var newRoot = currentRoot
+        temp.parent = node.parent
+
+        if (temp.leftChild != null) {
+            temp.leftChild?.parent = node
+        }
+        temp.rightChild = node
+        node.parent = temp
+
+        if (temp.parent != null) {
+            if (node == temp.parent?.leftChild) {
+                temp.parent?.leftChild = temp
+            } else {
+                temp.parent?.rightChild = temp
+            }
+        } else {
+            root = temp
+        }
+
+        return newRoot
+    }
+
+    private fun rotateLeft(node: RBNode<K, V>?, currentRoot: RBNode<K, V>?): RBNode<K, V>? {
+        val temp = node?.rightChild ?: return node // if right child is null, no rotation needed
+        var newRoot = currentRoot
+        temp.parent = node.parent
+
+        node.rightChild = temp.leftChild;
+        if (node.rightChild != null) {
+            node.rightChild?.parent = node;
+        }
+
+        temp.leftChild = node;
+        node.parent = temp;
+
+        // temp took over node's place so now its parent should point to temp
+        if (temp.parent != null) {
+            if (node == temp.parent?.leftChild) {
+                temp.parent?.leftChild = temp;
+            } else {
+                temp.parent?.rightChild = temp;
+            }
+        } else {
+            root = temp;
+            newRoot = temp
+        }
+        return newRoot
     }
 }


### PR DESCRIPTION
Fixed work of 'delete', 'fixAfterDeletion' and 'balanceNode' methods. 

The algo of 'fixAfterDeletion' was totally rewrote. 
Here is a brief explanation of the cases being handled:
1. If the sibling of the current node is red, perform rotations and color changes to adjust the tree.
2. If the sibling and its children are black, adjust colors and move up the tree.
3. Handle cases where the sibling has a black right child by performing rotations and color changes.
4. Adjust colors and perform rotations to fix the tree when the sibling is black and its right child is also black.

The rotation methods were moved to tree class due to their connection with current roots.
Code was refactored and lintered. Comments for stressed methods were added. 

TODO: print method?