### PR TITLE
Patch CI. Set up new check-coverage system, badge update and formatter test

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,18 @@
+version: 2
+mergeable:
+  - when: pull_request.*
+    name: "Description check"
+    validate:
+      - do: description
+        no_empty:
+          enabled: true
+          message: Description matter and should not be empty. Provide detail with **what** was changed, **why** it was changed, and **how** it was changed.
+          
+  - when: pull_request.opened
+    name: "Greet a contributor"
+    validate: []
+    pass:
+      - do: comment
+        payload:
+          body: >
+            Thanks for creating a pull request! A maintainer will review your changes shortly. Please don't be discouraged if it takes a while.

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -31,7 +31,7 @@ jobs:
 
       - if: matrix.os == 'ubuntu-latest'
         name: Generate Jacoco Badge
-        uses: cicirello/jacoco-badge-generator@2.11.0
+        uses: cicirello/jacoco-badge-generator@v2.11.0
         with:
           jacoco-csv-file: lib/build/jacoco/report.csv
           badges-directory: .github/badges

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ list.os }}
+    runs-on: ${{ matrix.os }}
         
     strategy:
       matrix:

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -2,32 +2,41 @@ name: Measure coverage
 
 on:
   workflow_dispatch:
-  pull_request: 
+  pull_request:
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-        
+
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ ubuntu-latest, macos-latest ]
 
     permissions:
       pull-requests: write
     
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: zulu
-      
+
       - name: Create Coverage Report
         run: |
           chmod +x gradlew
           ./gradlew jacocoTestReport
+
+      - if: matrix.os == 'ubuntu-latest'
+        name: Generate Jacoco Badge
+        uses: cicirello/jacoco-badge-generator@2.11.0
+        with:
+          jacoco-csv-file: lib/build/jacoco/report.csv
+          badges-directory: .github/badges
+          generate-coverage-badge: true
+          coverage-badge-filename: jacoco.svg
 
       - name: Add coverage to PR
         id: jacoco

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -37,3 +37,14 @@ jobs:
           badges-directory: .github/badges
           generate-coverage-badge: true
           coverage-badge-filename: jacoco.svg
+
+      - name: Commit the badges (if they changed)
+        run: |
+          if [[ `git diff --exit-code .github/badges` ]]; then
+          git config --global user.name 'qrutyy'
+          git config --global user.email 'qrutyq@gmail.com'
+          git add .github/badges/*
+          git commit -m "ci: autogenerate JaCoCo coverage badge"
+          git push || true
+          fi
+        shell: bash

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -37,14 +37,3 @@ jobs:
           badges-directory: .github/badges
           generate-coverage-badge: true
           coverage-badge-filename: jacoco.svg
-
-      - name: Add coverage to PR
-        id: jacoco
-        uses: madrapps/jacoco-report@v1.6.1
-        with:
-          paths: |
-            ${{ github.workspace }}/**/build/reports/jacoco/prodNormalDebugCoverage/prodNormalDebugCoverage.xml,
-            ${{ github.workspace }}/**/build/reports/jacoco/**/debugCoverage.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 10
-          min-coverage-changed-files: 10 // its temporary, for test only

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -10,7 +10,7 @@ jobs:
         
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macox-latest]
+        os: [ubuntu-latest, macos-latest]
 
     permissions:
       pull-requests: write

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -37,6 +37,6 @@ jobs:
             ${{ github.workspace }}/**/build/reports/jacoco/prodNormalDebugCoverage/prodNormalDebugCoverage.xml,
             ${{ github.workspace }}/**/build/reports/jacoco/**/debugCoverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 40
-          min-coverage-changed-files: 60
+          min-coverage-overall: 10
+          min-coverage-changed-files: 10 // its temporary, for test only
 

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -24,10 +24,10 @@ jobs:
           java-version: '17'
           distribution: zulu
       
-      - name: Run Coverage
+      - name: Create Coverage Report
         run: |
           chmod +x gradlew
-          ./gradlew testCoverage
+          ./gradlew jacocoTestReport
 
       - name: Add coverage to PR
         id: jacoco

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -2,34 +2,41 @@ name: Measure coverage
 
 on:
   workflow_dispatch:
+  push:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ list.os }}
+        
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macox-latest]
+
+    permissions:
+      pull-requests: write
+    
     steps:
       - uses: actions/checkout@v3
       
-      - name: Set up JDK
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: '17'
+          distribution: zulu
       
-      - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
-      
-      - name: Generate kover coverage report
-        run: ./gradlew koverXmlReport
+      - name: Run Coverage
+        run: |
+          chmod +x gradlew
+          ./gradlew testCoverage
 
-      - name: Add coverage report to PR
-        id: kover
-        uses: mi-kas/kover-report@v1
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.6.1
         with:
-          path: |
-            ${{ github.workspace }}/project1/build/reports/kover/report.xml
-            ${{ github.workspace }}/project2/build/reports/kover/report.xml
-          title: Code Coverage
-          update-comment: true
-          min-coverage-overall: 80
-          min-coverage-changed-files: 80
-          coverage-counter-type: LINE
+          paths: |
+            ${{ github.workspace }}/**/build/reports/jacoco/prodNormalDebugCoverage/prodNormalDebugCoverage.xml,
+            ${{ github.workspace }}/**/build/reports/jacoco/**/debugCoverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 40
+          min-coverage-changed-files: 60
 

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -2,7 +2,7 @@ name: Measure coverage
 
 on:
   workflow_dispatch:
-  push:
+  pull_request: 
 
 jobs:
   build:
@@ -39,4 +39,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 10
           min-coverage-changed-files: 10 // its temporary, for test only
-

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -1,0 +1,21 @@
+name: Verify formatting
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: zulu
+
+      - name: Run formatting test 
+        run: ./gradlew checkFormat

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Build & Run JUnit5 tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: zulu
+
+      - name: Build by Gradle
+        run: ./gradlew build
+
+      - name: Run JUnit5 tests 
+        run: ./gradlew test

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -63,9 +63,10 @@ tasks.jacocoTestReport {
     dependsOn(tasks.test) // tests are required to run before generating the report
 
     reports {
-        xml.required = true
+        xml.required = false
         html.required = true
-        csv.required = false
+        csv.required = true
+        csv.outputLocation.set(layout.buildDirectory.file("jacoco/report.csv"))
     }
 }
 
@@ -85,4 +86,3 @@ ktfmt {
 tasks.register("checkFormat") { dependsOn(tasks.ktfmtCheck) }
 
 tasks.register("format") { dependsOn(tasks.ktfmtFormat) }
-


### PR DESCRIPTION
Set up the handshake between JaCoCo coverage system and CI, by using badge-generator. After badge was generated, it will be uploaded to the server (in case it differs from the current one). 
Added merge rule for not empty description and cute user greeting)
Formatting verifier also was added as a part of PR actions.