### PR TITLE
Docs patch, add contribute rules and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
 labels: bug
-assignees: ''
 
 ---
 
@@ -24,8 +22,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
+ - OS: [e.g. macOS]
  - Version [e.g. 22]
 
 **Additional context**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# 💪 Interested in contributing?
+
+Good boy! Please read the few sections below to understand how to implement new features.
+
+> 😅 Be positive! Even if your changes don't get merged in forest-group, please don't be too sad, you will always be able to run workflows directly from your fork!
+>  Meow
+
+## 🤝 Accepted contributions
+
+The following contributions are accepted:
+<table>
+  <tr>
+    <th>Section</th>
+    <th>Changes</th>
+    <th>Additions</th>
+    <th>Notes</th>
+  </tr>
+  <tr>
+    <td nowrap="nowrap">🧩 Features</td>
+    <td>✔️</td>
+    <td>✔️</td>
+    <td>
+      <ul>
+        <li>New features are allowed, but must be optional and backward compatible</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td nowrap="nowrap">🧪 Tests</td>
+    <td>✔️</td>
+    <td>✔️</td>
+    <td>
+      <ul>
+        <li>Everything that makes forest-group more stable is welcomed!</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td nowrap="nowrap">🗃️ Repository</td>
+    <td>❌</td>
+    <td>❌</td>
+    <td>
+      <ul>
+        <li>Workflows, license, readmes, etc. usually don't need to be edited</li>
+      </ul>
+    </td>
+  </tr>
+</table>
+
+**Legend**
+* ✔️: Contributions welcomed!
+* ✓: Contributions are welcomed, but must be discussed first
+* ❌: Only maintainers can manage these files


### PR DESCRIPTION
Added a contribution guidelines file to provide clear instructions and criteria for accepting contributions to the forest-group project. Encourages positive and collaborative contributions while outlining what types of changes are accepted in features, tests, and repository files. #forest-group #meow 🌲🤝

Created a bug report template to facilitate the reporting of bugs and issues in the forest-group project. Includes sections for describing the bug, steps to reproduce, expected behavior, screenshots (if applicable), desktop information, and additional context.